### PR TITLE
fix: Regex: Push .Net version to fix GeneratedRegexAttribute

### DIFF
--- a/GodotUtils.csproj
+++ b/GodotUtils.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>disable</ImplicitUsings>
         <Nullable>disable</Nullable>


### PR DESCRIPTION
The attribute `[GeneratedRegex]` was used, but is only supported for ` > .NET7`.
Update to .NET8 to align with template version